### PR TITLE
feat: kill remote loading codepaths

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase/auth",
+  "name": "@exodus/firebase-auth",
   "version": "0.11.2",
   "main": "dist/auth.js",
   "module": "dist/auth.esm.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/firebase-auth",
-  "version": "0.11.2",
+  "version": "0.11.2-exodus.0",
   "main": "dist/auth.js",
   "module": "dist/auth.esm.js",
   "description": "Javascript library for Firebase Auth SDK",

--- a/packages/auth/src/iframeclient/iframewrapper.js
+++ b/packages/auth/src/iframeclient/iframewrapper.js
@@ -203,11 +203,6 @@ fireauth.iframeclient.IframeWrapper.prototype.unregisterEvent =
 };
 
 
-/** @private @const {!goog.string.Const} The GApi loader URL. */
-fireauth.iframeclient.IframeWrapper.GAPI_LOADER_SRC_ = goog.string.Const.from(
-    'https://apis.google.com/js/api.js?onload=%{onload}');
-
-
 /**
  * @private @const {!fireauth.util.Delay} The gapi.load network error timeout
  *     delay with units in ms.
@@ -295,9 +290,8 @@ fireauth.iframeclient.IframeWrapper.loadGApiJs_ = function() {
         }
       };
       // Build GApi loader.
-      var url = goog.html.TrustedResourceUrl.format(
-          fireauth.iframeclient.IframeWrapper.GAPI_LOADER_SRC_,
-          {'onload': cbName});
+      throw new Error('removed gapi src codepath')
+      var url
       // Load GApi loader.
       var result = goog.Promise.resolve(goog.net.jsloader.safeLoad(url));
       result.thenCatch(function(error) {

--- a/packages/auth/src/recaptchaverifier/realloader.js
+++ b/packages/auth/src/recaptchaverifier/realloader.js
@@ -55,13 +55,6 @@ fireauth.RecaptchaRealLoader = function() {
   this.cbName_ = '__rcb' + Math.floor(Math.random() * 1000000).toString();
 };
 
-
-/** @private @const {!goog.string.Const} The reCAPTCHA javascript source URL. */
-fireauth.RecaptchaRealLoader.RECAPTCHA_SRC_ = goog.string.Const.from(
-    'https://www.google.com/recaptcha/api.js?onload=%{onload}&render=explicit' +
-    '&hl=%{hl}');
-
-
 /**
  * The default timeout delay (units in milliseconds) for requests loading
  * the external reCAPTCHA dependencies.
@@ -124,11 +117,9 @@ fireauth.RecaptchaRealLoader.prototype.loadRecaptchaDeps =
         }
         delete goog.global[self.cbName_];
       };
-      // Construct reCAPTCHA URL and on load, run the temporary function.
-      var url = goog.html.TrustedResourceUrl.format(
-          fireauth.RecaptchaRealLoader.RECAPTCHA_SRC_,
-          {'onload': self.cbName_, 'hl': hl || ''});
+      throw new Error('removed recaptcha src codepath')
       // TODO: eventually, replace all dependencies on goog.net.jsloader.
+      var url
       goog.Promise.resolve(goog.net.jsloader.safeLoad(url))
           .thenCatch(function(error) {
             clearTimeout(timer);

--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -552,15 +552,6 @@ fireauth.RpcHandler.prototype.sendXhrUsingXhrIo_ = function(
   xhrIo.send(url, opt_httpMethod, opt_data, opt_headers);
 };
 
-
-/**
- * @const {!goog.string.Const} The GApi client library URL.
- * @private
- */
-fireauth.RpcHandler.GAPI_SRC_ = goog.string.Const.from(
-    'https://apis.google.com/js/client.js?onload=%{onload}');
-
-
 /**
  * @const {string}
  * @private
@@ -587,10 +578,9 @@ fireauth.RpcHandler.loadGApiJs_ = function(callback, errback) {
         callback();
       }
     };
-    var url = goog.html.TrustedResourceUrl.format(
-        fireauth.RpcHandler.GAPI_SRC_,
-        {'onload': fireauth.RpcHandler.GAPI_CALLBACK_NAME_});
+    throw new Error('removed gapi src codepath')
     // TODO: replace goog.net.jsloader with our own script includer.
+    var url
     var result = goog.net.jsloader.safeLoad(url);
     result.addErrback(function() {
       // In case file fails to load.


### PR DESCRIPTION
Kill places where remote code is loaded

Note: published `0.11.2-exodus.0` based on `78216f803e199adf801ce77cbe31ff56aefa8040`, but later rebased on @matias-la changes that I merged into the `exodus` branch